### PR TITLE
android: Use lib64 dir for arm64 builds

### DIFF
--- a/android/config.h
+++ b/android/config.h
@@ -14,7 +14,12 @@
 #define ALSA_DEVICE_DIRECTORY "/dev/snd/"
 
 /* directory containing ALSA add-on modules */
+#if defined(__aarch64__)
+/* If we are on an arm64 build -- then the lib dir is lib64. */
+#define ALSA_PLUGIN_DIR "/vendor/lib64/hw/"
+#else
 #define ALSA_PLUGIN_DIR "/vendor/lib/hw/"
+#endif
 
 /* Build hwdep component */
 #define BUILD_HWDEP "1"


### PR DESCRIPTION
Fixes this working on arm64 only Waydroid builds.

There is more stuff needed to make audio/media stuff work there that is not this though, but some of it might break 32-bit stuff.